### PR TITLE
docs(README): add example for ewrap.Newf function

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ err := ewrap.New("database connection failed")
 if err != nil {
     return ewrap.Wrap(err, "failed to process request")
 }
+
+err = ewrap.Newf("failed to process request id: %v", requestID)
 ```
 
 ### Advanced Error Context


### PR DESCRIPTION
Add code example demonstrating how to create formatted error messages with the ewrap.Newf function that includes dynamic values like requestID. This complements the existing examples for basic error creation and wrapping.