### PR TITLE
docs(getting-started): add examples 

### DIFF
--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -20,6 +20,13 @@ err := ewrap.New("database connection failed")
 if err != nil {
     return ewrap.Wrap(err, "failed to process request")
 }
+
+// Create a new error with context
+err := ewrap.Newf("operation failed: %w", err)
+    ewrap.WithContext(ctx, ewrap.ErrorTypeDatabase, ewrap.SeverityCritical),
+    ewrap.WithLogger(logger))
+
+err.Log()
 ```
 
 ### Advanced Error Context


### PR DESCRIPTION
Examples for creating errors with context and logging.