### PR TITLE
refactor: improve timestamp formatting and error handling

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -302,34 +302,32 @@ func TestCaptureStack(t *testing.T) {
 func TestError_Is(t *testing.T) {
 	t.Run("returns false for nil target", func(t *testing.T) {
 		err := New("test")
-		if err.Is(nil) {
+		if errors.Is(err, nil) {
 			t.Error("expected false for nil target")
 		}
 	})
 
-	t.Run("matches message", func(t *testing.T) {
+	t.Run("matches sentinel error", func(t *testing.T) {
+		sentinel := errors.New("sentinel")
+		wrapped := Wrap(sentinel, "wrapped")
+		if !errors.Is(wrapped, sentinel) {
+			t.Error("expected true for sentinel error in chain")
+		}
+	})
+
+	t.Run("matches ewrap sentinel", func(t *testing.T) {
+		sentinel := New("sentinel")
+		wrapped := Wrap(sentinel, "wrapped")
+		if !errors.Is(wrapped, sentinel) {
+			t.Error("expected true for ewrap sentinel in chain")
+		}
+	})
+
+	t.Run("non-matching error", func(t *testing.T) {
 		err := New("test error")
-		target := errors.New("test error")
-		if !err.Is(target) {
-			t.Error("expected true for matching message")
-		}
-	})
-
-	t.Run("matches in chain", func(t *testing.T) {
-		original := New("original")
-		wrapped := Wrap(original, "wrapped")
-		target := errors.New("original")
-		if !wrapped.Is(target) {
-			t.Error("expected true for message in chain")
-		}
-	})
-
-	t.Run("matches standard error in chain", func(t *testing.T) {
-		original := errors.New("original")
-		wrapped := Wrap(original, "wrapped")
-		target := errors.New("original")
-		if !wrapped.Is(target) {
-			t.Error("expected true for standard error in chain")
+		target := errors.New("other")
+		if errors.Is(err, target) {
+			t.Error("expected false for non-matching error")
 		}
 	})
 }

--- a/format.go
+++ b/format.go
@@ -16,7 +16,7 @@ type ErrorOutput struct {
 	// Message contains the main error message
 	Message string `json:"message" yaml:"message"`
 	// Timestamp indicates when the error occurred
-	Timestamp time.Time `json:"timestamp" yaml:"timestamp"`
+	Timestamp string `json:"timestamp" yaml:"timestamp"`
 	// Type categorizes the error
 	Type string `json:"type" yaml:"type"`
 	// Severity indicates the error's impact level
@@ -37,8 +37,13 @@ type FormatOption func(*ErrorOutput)
 // WithTimestampFormat allows customizing the timestamp format in the output.
 func WithTimestampFormat(format string) FormatOption {
 	return func(eo *ErrorOutput) {
-		if format != "" {
-			eo.Timestamp = eo.Timestamp.Round(time.Second)
+		if format == "" {
+			return
+		}
+
+		// Attempt to parse existing timestamp and reformat
+		if t, err := time.Parse(time.RFC3339, eo.Timestamp); err == nil {
+			eo.Timestamp = t.Format(format)
 		}
 	}
 }
@@ -80,7 +85,7 @@ func (e *Error) toErrorOutput(opts ...FormatOption) *ErrorOutput {
 	// Create base output structure
 	output := &ErrorOutput{
 		Message:   e.msg,
-		Timestamp: time.Now(),
+		Timestamp: time.Now().Format(time.RFC3339),
 		Type:      "unknown",
 		Severity:  "error",
 		Stack:     e.Stack(),

--- a/format_test.go
+++ b/format_test.go
@@ -11,26 +11,24 @@ import (
 )
 
 func TestWithTimestampFormat(t *testing.T) {
+	tFixed := time.Date(2024, 1, 2, 15, 4, 5, 0, time.UTC)
 	output := &ErrorOutput{
-		Timestamp: time.Now(),
+		Timestamp: tFixed.Format(time.RFC3339),
 	}
 
 	// Test with non-empty format
 	opt := WithTimestampFormat("2006-01-02")
 	opt(output)
-
-	// Timestamp should be rounded to seconds
-	if output.Timestamp.Nanosecond() != 0 {
-		t.Error("Expected timestamp to be rounded to seconds")
+	expected := tFixed.Format("2006-01-02")
+	if output.Timestamp != expected {
+		t.Errorf("Expected timestamp %s, got %s", expected, output.Timestamp)
 	}
 
 	// Test with empty format
+	output.Timestamp = tFixed.Format(time.RFC3339)
 	opt = WithTimestampFormat("")
-	originalTime := output.Timestamp
 	opt(output)
-
-	// Timestamp should remain unchanged
-	if !output.Timestamp.Equal(originalTime) {
+	if output.Timestamp != tFixed.Format(time.RFC3339) {
 		t.Error("Expected timestamp to remain unchanged with empty format")
 	}
 }
@@ -162,9 +160,8 @@ func TestToErrorOutputWithOptions(t *testing.T) {
 		t.Error("Expected stack trace to be empty")
 	}
 
-	// Check that timestamp was rounded
-	if output.Timestamp.Nanosecond() != 0 {
-		t.Error("Expected timestamp to be rounded")
+	if _, err := time.Parse("2006-01-02", output.Timestamp); err != nil {
+		t.Errorf("Expected timestamp in format 2006-01-02, got %s", output.Timestamp)
 	}
 }
 


### PR DESCRIPTION
## Summary
- format timestamp output as strings and allow custom layouts
- switch `Error.Is` to standard sentinel error comparisons
- store error context in metadata for unified access

## Testing
- `go test ./...`
- `pre-commit run --files errors.go format.go errors_test.go format_test.go` *(fails: Go language version mismatch in golangci-lint)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e4f1bf48330a6ed1754c51d496d