### PR TITLE
fix: resolve infinite recursion in Error.Is() method and improve code quality

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -323,6 +323,15 @@ func TestError_Is(t *testing.T) {
 		}
 	})
 
+	t.Run("prevents infinite recursion with self-reference", func(t *testing.T) {
+		err1 := New("error1")
+		err2 := New("error2")
+		// This would create a cycle if not handled properly
+		if errors.Is(err1, err2) {
+			t.Error("expected false for different errors")
+		}
+	})
+
 	t.Run("non-matching error", func(t *testing.T) {
 		err := New("test error")
 		target := errors.New("other")

--- a/format.go
+++ b/format.go
@@ -42,7 +42,8 @@ func WithTimestampFormat(format string) FormatOption {
 		}
 
 		// Attempt to parse existing timestamp and reformat
-		if t, err := time.Parse(time.RFC3339, eo.Timestamp); err == nil {
+		t, err := time.Parse(time.RFC3339, eo.Timestamp)
+		if err == nil {
 			eo.Timestamp = t.Format(format)
 		}
 	}


### PR DESCRIPTION
- Fix stack overflow in Error.Is() by replacing recursive errors.Is call with proper comparison logic
- Add message comparison fallback for standard error compatibility
- Replace manual map iteration with maps.Copy() for better performance
- Add test case to prevent infinite recursion regressions
- Improve code readability in timestamp formatting logic

This resolves the critical stack overflow issue that occurred when comparing ewrap errors, ensuring proper error chain traversal without infinite loops.