### PR TITLE
feat: enhance retry and recovery features

### DIFF
--- a/format.go
+++ b/format.go
@@ -29,6 +29,8 @@ type ErrorOutput struct {
 	Context map[string]any `json:"context,omitempty" yaml:"context,omitempty"`
 	// Metadata contains user-defined metadata
 	Metadata map[string]any `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	// Recovery provides guidance on resolving the error
+	Recovery *RecoverySuggestion `json:"recovery,omitempty" yaml:"recovery,omitempty"`
 }
 
 // FormatOption defines formatting options for error output.
@@ -67,6 +69,7 @@ func (e *Error) toErrorOutput(opts ...FormatOption) *ErrorOutput {
 	var (
 		ctx        *ErrorContext
 		contextMap map[string]any
+		recovery   *RecoverySuggestion
 	)
 
 	if rawCtx, ok := e.metadata["error_context"]; ok {
@@ -83,6 +86,10 @@ func (e *Error) toErrorOutput(opts ...FormatOption) *ErrorOutput {
 		}
 	}
 
+	if rawRec, ok := e.metadata["recovery_suggestion"]; ok {
+		recovery, _ = rawRec.(*RecoverySuggestion)
+	}
+
 	// Create base output structure
 	output := &ErrorOutput{
 		Message:   e.msg,
@@ -92,11 +99,12 @@ func (e *Error) toErrorOutput(opts ...FormatOption) *ErrorOutput {
 		Stack:     e.Stack(),
 		Context:   contextMap,
 		Metadata:  make(map[string]any),
+		Recovery:  recovery,
 	}
 
 	// Copy metadata excluding internal keys
 	for k, v := range e.metadata {
-		if k != "error_context" {
+		if k != "error_context" && k != "recovery_suggestion" {
 			output.Metadata[k] = v
 		}
 	}

--- a/format_test.go
+++ b/format_test.go
@@ -261,3 +261,26 @@ func TestToErrorOutputWithMetadata(t *testing.T) {
 		t.Error("Expected error_context to be excluded from metadata")
 	}
 }
+
+func TestToErrorOutputWithRecoverySuggestion(t *testing.T) {
+	rs := &RecoverySuggestion{
+		Message:       "restart service",
+		Actions:       []string{"restart"},
+		Documentation: "https://example.com/recover",
+	}
+
+	err := New("test error", WithRecoverySuggestion(rs))
+	output := err.toErrorOutput()
+
+	if output.Recovery == nil {
+		t.Fatal("expected recovery suggestion to be present")
+	}
+
+	if output.Recovery.Message != rs.Message {
+		t.Errorf("expected recovery message '%s', got '%s'", rs.Message, output.Recovery.Message)
+	}
+
+	if output.Recovery.Documentation != rs.Documentation {
+		t.Errorf("expected documentation '%s', got '%s'", rs.Documentation, output.Recovery.Documentation)
+	}
+}

--- a/retry_test.go
+++ b/retry_test.go
@@ -42,6 +42,13 @@ func TestCanRetry(t *testing.T) {
 	})
 }
 
+func TestWithRetryCustomShouldRetry(t *testing.T) {
+	shouldRetry := func(error) bool { return false }
+	err := New("test error", WithRetry(3, time.Second, WithRetryShould(shouldRetry)))
+
+	assert.False(t, err.CanRetry())
+}
+
 func TestDefaultShouldRetry(t *testing.T) {
 	t.Run("ValidationError", func(t *testing.T) {
 		err := New("validation error").


### PR DESCRIPTION
## Summary
- allow custom retry deciders via `WithRetryShould`
- expose recovery suggestions and include in formatted output
- add generic metadata accessor for typed context

## Testing
- `go test ./...`
- `pre-commit run --files errors.go errors_test.go format.go format_test.go retry.go retry_test.go` *(fails: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0))*

------
https://chatgpt.com/codex/tasks/task_e_68a43eb104648330b2f9c3dfdf0b82c5