### PR TITLE
feat: add observability hooks

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -252,6 +252,8 @@ func (e *Error) Stack() string {
 
 // Log logs the error using the configured logger.
 func (e *Error) Log() {
+	observer.RecordError(e.msg)
+
 	e.mu.RLock()
 	logger := e.logger
 	e.mu.RUnlock()

--- a/observability.go
+++ b/observability.go
@@ -1,0 +1,26 @@
+package ewrap
+
+// Observer defines hooks for observing errors and circuit breaker state transitions.
+type Observer interface {
+	// RecordError is called when an error is logged.
+	RecordError(message string)
+	// RecordCircuitStateTransition is called when a circuit breaker changes state.
+	RecordCircuitStateTransition(name string, from, to CircuitState)
+}
+
+// noopObserver provides a no-op implementation of the Observer interface.
+type noopObserver struct{}
+
+func (noopObserver) RecordError(string)                                              {}
+func (noopObserver) RecordCircuitStateTransition(string, CircuitState, CircuitState) {}
+
+var observer Observer = noopObserver{}
+
+// SetObserver sets the global observer. Passing nil resets to a no-op observer.
+func SetObserver(o Observer) {
+	if o == nil {
+		observer = noopObserver{}
+		return
+	}
+	observer = o
+}

--- a/observability_test.go
+++ b/observability_test.go
@@ -1,0 +1,71 @@
+package ewrap
+
+import (
+	"testing"
+	"time"
+)
+
+type testObserver struct {
+	errorCount  int
+	transitions []stateChange
+}
+
+type stateChange struct {
+	name string
+	from CircuitState
+	to   CircuitState
+}
+
+func (t *testObserver) RecordError(string) {
+	t.errorCount++
+}
+
+func (t *testObserver) RecordCircuitStateTransition(name string, from, to CircuitState) {
+	t.transitions = append(t.transitions, stateChange{name: name, from: from, to: to})
+}
+
+func TestErrorLogRecordsObserver(t *testing.T) {
+	obs := &testObserver{}
+	SetObserver(obs)
+	defer SetObserver(nil)
+
+	err := New("boom")
+	err.Log()
+
+	if obs.errorCount != 1 {
+		t.Fatalf("expected 1 error recorded, got %d", obs.errorCount)
+	}
+}
+
+func TestCircuitBreakerObserver(t *testing.T) {
+	obs := &testObserver{}
+	SetObserver(obs)
+	defer SetObserver(nil)
+
+	timeout := 10 * time.Millisecond
+	cb := NewCircuitBreaker("test", 1, timeout)
+
+	cb.RecordFailure()
+	time.Sleep(timeout + time.Millisecond)
+	if !cb.CanExecute() {
+		t.Fatalf("expected circuit breaker to allow execution after timeout")
+	}
+	cb.RecordSuccess()
+
+	expected := []stateChange{
+		{name: "test", from: CircuitClosed, to: CircuitOpen},
+		{name: "test", from: CircuitOpen, to: CircuitHalfOpen},
+		{name: "test", from: CircuitHalfOpen, to: CircuitClosed},
+	}
+
+	if len(obs.transitions) != len(expected) {
+		t.Fatalf("expected %d transitions, got %d", len(expected), len(obs.transitions))
+	}
+
+	for i, exp := range expected {
+		got := obs.transitions[i]
+		if got != exp {
+			t.Errorf("transition %d: expected %+v, got %+v", i, exp, got)
+		}
+	}
+}

--- a/threshold.go
+++ b/threshold.go
@@ -106,6 +106,8 @@ func (cb *CircuitBreaker) transitionTo(newState CircuitState) {
 	oldState := cb.state
 	cb.state = newState
 
+	observer.RecordCircuitStateTransition(cb.name, oldState, newState)
+
 	if cb.onStateChange != nil {
 		go cb.onStateChange(cb.name, oldState, newState)
 	}


### PR DESCRIPTION
## Summary
- add Observer interface for error and circuit-breaker telemetry
- emit metrics when errors are logged and circuit breakers change state
- test observability hooks

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68a44781c2a08330862e95e64c870a47