### PR TITLE
feat: add ErrorGroup serialization and stack frame inspection

### DIFF
--- a/__examples/serialization/serialization_example.go
+++ b/__examples/serialization/serialization_example.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/goccy/go-json"
+
+	"github.com/hyp3rd/ewrap"
+)
+
+func main() {
+	// Example 1: ErrorGroup serialization
+	fmt.Println("=== ErrorGroup Serialization Example ===")
+
+	eg := ewrap.NewErrorGroup()
+
+	// Add various types of errors
+	eg.Add(ewrap.New("first error").WithMetadata("key1", "value1"))
+	eg.Add(ewrap.Wrap(fmt.Errorf("standard error"), "wrapped standard error"))
+	eg.Add(ewrap.New("another error").WithMetadata("severity", "high"))
+
+	// Serialize to JSON
+	jsonData, err := eg.ToJSON()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("JSON serialization:\n%s\n\n", string(jsonData))
+
+	// Serialize to YAML
+	yamlData, err := eg.ToYAML()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("YAML serialization:\n%s\n\n", string(yamlData))
+
+	// Example 2: Stack frame inspection
+	fmt.Println("=== Stack Frame Inspection Example ===")
+
+	err1 := createErrorInFunction()
+
+	// Get stack iterator
+	iterator := err1.GetStackIterator()
+
+	fmt.Println("Stack frames:")
+	frameNum := 0
+	for iterator.HasNext() {
+		frame := iterator.Next()
+		fmt.Printf("Frame %d: %s:%d in %s\n",
+			frameNum, frame.File, frame.Line, frame.Function)
+		frameNum++
+
+		// Limit output for readability
+		if frameNum >= 5 {
+			break
+		}
+	}
+
+	// Example 3: Get all stack frames as slice
+	fmt.Println("\n=== All Stack Frames ===")
+	frames := err1.GetStackFrames()
+	for i, frame := range frames {
+		fmt.Printf("Frame %d: %s:%d in %s\n",
+			i, frame.File, frame.Line, frame.Function)
+		if i >= 3 { // Limit for readability
+			break
+		}
+	}
+
+	// Example 4: Structured error representation
+	fmt.Println("\n=== Structured Error Representation ===")
+	serializable := eg.ToSerialization()
+
+	for i, serErr := range serializable.Errors {
+		fmt.Printf("Error %d:\n", i+1)
+		fmt.Printf("  Type: %s\n", serErr.Type)
+		fmt.Printf("  Message: %s\n", serErr.Message)
+		fmt.Printf("  Stack frames: %d\n", len(serErr.StackTrace))
+		if serErr.Metadata != nil {
+			metadataJson, _ := json.MarshalIndent(serErr.Metadata, "  ", "  ")
+			fmt.Printf("  Metadata: %s\n", string(metadataJson))
+		}
+		fmt.Println()
+	}
+}
+
+func createErrorInFunction() *ewrap.Error {
+	return ewrap.New("error created in function").WithMetadata("context", "example")
+}

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -7,6 +7,7 @@ words:
   - excludeonly
   - Fprintf
   - Fprintln
+  - goccy
   - sarif
 ignoreWords: []
 import: []

--- a/error_group.go
+++ b/error_group.go
@@ -7,6 +7,10 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/goccy/go-json"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -164,4 +168,118 @@ func (eg *ErrorGroup) Clear() {
 	eg.mu.Lock()
 	eg.errors = eg.errors[:0]
 	eg.mu.Unlock()
+}
+
+// SerializableError represents an error in a serializable format.
+type SerializableError struct {
+	Message    string                 `json:"message"               yaml:"message"`
+	Type       string                 `json:"type"                  yaml:"type"`
+	StackTrace []StackFrame           `json:"stack_trace,omitempty" yaml:"stack_trace,omitempty"`
+	Metadata   map[string]interface{} `json:"metadata,omitempty"    yaml:"metadata,omitempty"`
+	Cause      *SerializableError     `json:"cause,omitempty"       yaml:"cause,omitempty"`
+}
+
+// ErrorGroupSerialization represents the serializable format of an ErrorGroup.
+type ErrorGroupSerialization struct {
+	ErrorCount int                 `json:"error_count" yaml:"error_count"`
+	Timestamp  string              `json:"timestamp"   yaml:"timestamp"`
+	Errors     []SerializableError `json:"errors"      yaml:"errors"`
+}
+
+// toSerializableError converts an error to a SerializableError.
+func toSerializableError(err error) SerializableError {
+	if err == nil {
+		return SerializableError{}
+	}
+
+	serErr := SerializableError{
+		Message: err.Error(),
+		Type:    "standard",
+	}
+
+	// Check if it's our custom Error type
+	customErr := &Error{}
+	if errors.As(err, &customErr) {
+		serErr.Type = "ewrap"
+		serErr.StackTrace = customErr.GetStackFrames()
+
+		// Get metadata safely
+		customErr.mu.RLock()
+
+		if len(customErr.metadata) > 0 {
+			serErr.Metadata = make(map[string]interface{}, len(customErr.metadata))
+			for k, v := range customErr.metadata {
+				serErr.Metadata[k] = v
+			}
+		}
+
+		customErr.mu.RUnlock()
+
+		// Handle cause
+		if customErr.cause != nil {
+			cause := toSerializableError(customErr.cause)
+			serErr.Cause = &cause
+		}
+	}
+
+	return serErr
+}
+
+// ToSerialization converts the ErrorGroup to a serializable format.
+func (eg *ErrorGroup) ToSerialization() ErrorGroupSerialization {
+	eg.mu.RLock()
+	defer eg.mu.RUnlock()
+
+	serializable := ErrorGroupSerialization{
+		ErrorCount: len(eg.errors),
+		Timestamp:  time.Now().Format(time.RFC3339),
+		Errors:     make([]SerializableError, len(eg.errors)),
+	}
+
+	for i, err := range eg.errors {
+		serializable.Errors[i] = toSerializableError(err)
+	}
+
+	return serializable
+}
+
+// ToJSON converts the ErrorGroup to JSON format.
+func (eg *ErrorGroup) ToJSON() (string, error) {
+	serializable := eg.ToSerialization()
+
+	data, err := json.MarshalIndent(serializable, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal ErrorGroup to JSON: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// ToYAML converts the ErrorGroup to YAML format.
+func (eg *ErrorGroup) ToYAML() (string, error) {
+	serializable := eg.ToSerialization()
+
+	data, err := yaml.Marshal(serializable)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal ErrorGroup to YAML: %w", err)
+	}
+
+	return string(data), nil
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (eg *ErrorGroup) MarshalJSON() ([]byte, error) {
+	serializable := eg.ToSerialization()
+
+	data, err := json.Marshal(serializable)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ErrorGroup to JSON: %w", err)
+	}
+
+	return data, nil
+}
+
+// MarshalYAML implements the yaml.Marshaler interface.
+func (eg *ErrorGroup) MarshalYAML() (interface{}, error) {
+	return eg.ToSerialization(), nil
 }

--- a/example_observer.go
+++ b/example_observer.go
@@ -1,0 +1,81 @@
+package ewrap
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"time"
+)
+
+const (
+	// maxFailures is the maximum number of failures before opening the circuit.
+	maxFailures = 3
+	// maxTimeout is the maximum timeout for circuit breakers.
+	maxTimeout = 5 * time.Second
+)
+
+// MetricsObserver is an example observer that tracks metrics.
+type MetricsObserver struct {
+	errorCount      int
+	circuitBreakers map[string]CircuitState
+}
+
+// NewMetricsObserver creates a new MetricsObserver.
+func NewMetricsObserver() *MetricsObserver {
+	return &MetricsObserver{
+		circuitBreakers: make(map[string]CircuitState),
+	}
+}
+
+// RecordError records an error occurrence.
+func (m *MetricsObserver) RecordError(message string) {
+	m.errorCount++
+	log.Printf("Error recorded: %s (total: %d)", message, m.errorCount)
+}
+
+// RecordCircuitStateTransition records a circuit state transition.
+func (m *MetricsObserver) RecordCircuitStateTransition(name string, from, to CircuitState) {
+	m.circuitBreakers[name] = to
+	log.Printf("Circuit breaker '%s' transitioned from %d to %d", name, from, to)
+}
+
+// GetErrorCount retrieves the total number of errors recorded.
+func (m *MetricsObserver) GetErrorCount() int {
+	return m.errorCount
+}
+
+// GetCircuitState retrieves the current state of a circuit breaker.
+func (m *MetricsObserver) GetCircuitState(name string) (CircuitState, bool) {
+	state, exists := m.circuitBreakers[name]
+
+	return state, exists
+}
+
+// ExampleObserverUsage demonstrates the new observer design.
+func ExampleObserverUsage() {
+	// Create a metrics observer
+	metrics := NewMetricsObserver()
+
+	// Create errors with observer
+	err1 := New("database connection failed", WithObserver(metrics))
+	err2 := Wrap(err1, "failed to fetch user data")
+
+	// Log errors (will be recorded by observer)
+	err1.Log()
+	err2.Log() // Will inherit observer from err1
+
+	// Create circuit breaker with observer
+	cb := NewCircuitBreakerWithObserver("database", maxFailures, maxTimeout, metrics)
+
+	// Simulate failures
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure() // This will open the circuit
+
+	// Check metrics
+	fmt.Fprintf(os.Stdout, "Total errors: %d\n", metrics.GetErrorCount())
+
+	if state, exists := metrics.GetCircuitState("database"); exists {
+		fmt.Fprintf(os.Stdout, "Database circuit state: %d\n", state)
+	}
+}

--- a/format.go
+++ b/format.go
@@ -2,11 +2,11 @@
 package ewrap
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
 
+	"github.com/goccy/go-json"
 	"gopkg.in/yaml.v3"
 )
 

--- a/format_test.go
+++ b/format_test.go
@@ -1,12 +1,12 @@
 package ewrap
 
 import (
-	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/goccy/go-json"
 	"gopkg.in/yaml.v3"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.0
 require (
 	emperror.dev/emperror v0.33.0
 	emperror.dev/errors v0.8.1
+	github.com/goccy/go-json v0.10.5
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/rs/zerolog v1.34.0
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
+github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/observability.go
+++ b/observability.go
@@ -11,16 +11,9 @@ type Observer interface {
 // noopObserver provides a no-op implementation of the Observer interface.
 type noopObserver struct{}
 
+func newNoopObserver() Observer {
+	return noopObserver{}
+}
+
 func (noopObserver) RecordError(string)                                              {}
 func (noopObserver) RecordCircuitStateTransition(string, CircuitState, CircuitState) {}
-
-var observer Observer = noopObserver{}
-
-// SetObserver sets the global observer. Passing nil resets to a no-op observer.
-func SetObserver(o Observer) {
-	if o == nil {
-		observer = noopObserver{}
-		return
-	}
-	observer = o
-}

--- a/observability_test.go
+++ b/observability_test.go
@@ -26,10 +26,8 @@ func (t *testObserver) RecordCircuitStateTransition(name string, from, to Circui
 
 func TestErrorLogRecordsObserver(t *testing.T) {
 	obs := &testObserver{}
-	SetObserver(obs)
-	defer SetObserver(nil)
 
-	err := New("boom")
+	err := New("boom", WithObserver(obs))
 	err.Log()
 
 	if obs.errorCount != 1 {
@@ -39,11 +37,9 @@ func TestErrorLogRecordsObserver(t *testing.T) {
 
 func TestCircuitBreakerObserver(t *testing.T) {
 	obs := &testObserver{}
-	SetObserver(obs)
-	defer SetObserver(nil)
 
 	timeout := 10 * time.Millisecond
-	cb := NewCircuitBreaker("test", 1, timeout)
+	cb := NewCircuitBreakerWithObserver("test", 1, timeout, obs)
 
 	cb.RecordFailure()
 	time.Sleep(timeout + time.Millisecond)
@@ -68,4 +64,58 @@ func TestCircuitBreakerObserver(t *testing.T) {
 			t.Errorf("transition %d: expected %+v, got %+v", i, exp, got)
 		}
 	}
+}
+
+func TestObserverInheritanceInWrap(t *testing.T) {
+	obs := &testObserver{}
+
+	// Create original error with observer
+	original := New("original error", WithObserver(obs))
+
+	// Wrap the error - should inherit the observer
+	wrapped := Wrap(original, "wrapped error")
+
+	// Log both errors
+	original.Log()
+	wrapped.Log()
+
+	// Should record 2 errors
+	if obs.errorCount != 2 {
+		t.Fatalf("expected 2 errors recorded, got %d", obs.errorCount)
+	}
+}
+
+func TestCircuitBreakerSetObserver(t *testing.T) {
+	obs := &testObserver{}
+
+	// Create circuit breaker without observer
+	cb := NewCircuitBreaker("test", 1, 10*time.Millisecond)
+
+	// Set observer later
+	cb.SetObserver(obs)
+
+	// Trigger a state transition
+	cb.RecordFailure()
+
+	expected := []stateChange{
+		{name: "test", from: CircuitClosed, to: CircuitOpen},
+	}
+
+	if len(obs.transitions) != len(expected) {
+		t.Fatalf("expected %d transitions, got %d", len(expected), len(obs.transitions))
+	}
+
+	if obs.transitions[0] != expected[0] {
+		t.Errorf("expected %+v, got %+v", expected[0], obs.transitions[0])
+	}
+}
+
+func TestObserverIsOptional(t *testing.T) {
+	// Create error without observer - should not panic
+	err := New("test error")
+	err.Log() // Should not panic
+
+	// Create circuit breaker without observer - should not panic
+	cb := NewCircuitBreaker("test", 1, 10*time.Millisecond)
+	cb.RecordFailure() // Should not panic
 }

--- a/stack.go
+++ b/stack.go
@@ -1,0 +1,105 @@
+package ewrap
+
+import (
+	"runtime"
+	"strings"
+)
+
+// StackFrame represents a single frame in a stack trace.
+type StackFrame struct {
+	// Function is the fully qualified function name
+	Function string `json:"function" yaml:"function"`
+	// File is the source file path
+	File string `json:"file" yaml:"file"`
+	// Line is the line number in the source file
+	Line int `json:"line" yaml:"line"`
+	// PC is the program counter for this frame
+	PC uintptr `json:"pc" yaml:"pc"`
+}
+
+// StackTrace represents a collection of stack frames.
+type StackTrace []StackFrame
+
+// StackIterator provides a way to iterate through stack frames.
+type StackIterator struct {
+	frames []StackFrame
+	index  int
+}
+
+// NewStackIterator creates a new stack iterator from program counters.
+func NewStackIterator(pcs []uintptr) *StackIterator {
+	frames := make([]StackFrame, 0, len(pcs))
+	callersFrames := runtime.CallersFrames(pcs)
+
+	for {
+		frame, more := callersFrames.Next()
+
+		// Skip runtime frames and error package frames
+		if !strings.Contains(frame.File, "runtime/") &&
+			!strings.Contains(frame.File, "ewrap/errors.go") {
+			frames = append(frames, StackFrame{
+				Function: frame.Function,
+				File:     frame.File,
+				Line:     frame.Line,
+				PC:       frame.PC,
+			})
+		}
+
+		if !more {
+			break
+		}
+	}
+
+	return &StackIterator{
+		frames: frames,
+		index:  0,
+	}
+}
+
+// Next returns the next stack frame, or nil if no more frames.
+func (si *StackIterator) Next() *StackFrame {
+	if si.index >= len(si.frames) {
+		return nil
+	}
+
+	frame := &si.frames[si.index]
+	si.index++
+
+	return frame
+}
+
+// HasNext returns true if there are more frames to iterate.
+func (si *StackIterator) HasNext() bool {
+	return si.index < len(si.frames)
+}
+
+// Reset resets the iterator to the beginning.
+func (si *StackIterator) Reset() {
+	si.index = 0
+}
+
+// Frames returns all remaining frames as a slice.
+func (si *StackIterator) Frames() []StackFrame {
+	if si.index >= len(si.frames) {
+		return nil
+	}
+
+	return si.frames[si.index:]
+}
+
+// AllFrames returns all frames regardless of current position.
+func (si *StackIterator) AllFrames() []StackFrame {
+	return si.frames
+}
+
+// GetStackIterator returns a stack iterator for the error's stack trace.
+func (e *Error) GetStackIterator() *StackIterator {
+	return NewStackIterator(e.stack)
+}
+
+// GetStackFrames returns all stack frames as a slice.
+func (e *Error) GetStackFrames() []StackFrame {
+	iterator := e.GetStackIterator()
+
+	return iterator.AllFrames()
+}

--- a/stack_test.go
+++ b/stack_test.go
@@ -1,0 +1,274 @@
+package ewrap
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-json"
+	"gopkg.in/yaml.v3"
+)
+
+func TestStackIterator(t *testing.T) {
+	// Create an error to get a stack trace
+	err := New("test error")
+	iterator := err.GetStackIterator()
+
+	// Test HasNext and Next
+	frameCount := 0
+	for iterator.HasNext() {
+		frame := iterator.Next()
+		if frame == nil {
+			t.Error("Expected frame, got nil")
+		}
+		frameCount++
+	}
+
+	if frameCount == 0 {
+		t.Error("Expected at least one frame")
+	}
+
+	// Test that Next returns nil after iteration is complete
+	if iterator.Next() != nil {
+		t.Error("Expected nil after iteration complete")
+	}
+
+	// Test Reset
+	iterator.Reset()
+	if !iterator.HasNext() {
+		t.Error("Expected frames after reset")
+	}
+
+	// Test AllFrames
+	allFrames := iterator.AllFrames()
+	if len(allFrames) != frameCount {
+		t.Errorf("Expected %d frames, got %d", frameCount, len(allFrames))
+	}
+}
+
+func TestStackFrameStructure(t *testing.T) {
+	err := New("test error")
+	frames := err.GetStackFrames()
+
+	if len(frames) == 0 {
+		t.Error("Expected at least one frame")
+	}
+
+	frame := frames[0]
+	if frame.Function == "" {
+		t.Error("Expected function name")
+	}
+	if frame.File == "" {
+		t.Error("Expected file name")
+	}
+	if frame.Line == 0 {
+		t.Error("Expected line number")
+	}
+	if frame.PC == 0 {
+		t.Error("Expected program counter")
+	}
+}
+
+func TestErrorGroupSerialization(t *testing.T) {
+	eg := NewErrorGroup()
+
+	// Add different types of errors
+	eg.Add(New("ewrap error").WithMetadata("key", "value"))
+	eg.Add(New("another error"))
+
+	// Test ToSerialization
+	serializable := eg.ToSerialization()
+
+	if serializable.ErrorCount != 2 {
+		t.Errorf("Expected 2 errors, got %d", serializable.ErrorCount)
+	}
+
+	if len(serializable.Errors) != 2 {
+		t.Errorf("Expected 2 serialized errors, got %d", len(serializable.Errors))
+	}
+
+	// Check first error
+	firstErr := serializable.Errors[0]
+	if firstErr.Type != "ewrap" {
+		t.Errorf("Expected type 'ewrap', got '%s'", firstErr.Type)
+	}
+
+	if firstErr.Message != "ewrap error" {
+		t.Errorf("Expected message 'ewrap error', got '%s'", firstErr.Message)
+	}
+
+	if firstErr.Metadata == nil || firstErr.Metadata["key"] != "value" {
+		t.Error("Expected metadata to be preserved")
+	}
+
+	if len(firstErr.StackTrace) == 0 {
+		t.Error("Expected stack trace in serialized error")
+	}
+}
+
+func TestErrorGroupJSON(t *testing.T) {
+	eg := NewErrorGroup()
+	eg.Add(New("test error"))
+
+	// Test ToJSON
+	jsonStr, err := eg.ToJSON()
+	if err != nil {
+		t.Fatalf("Failed to convert to JSON: %v", err)
+	}
+
+	if jsonStr == "" {
+		t.Error("Expected non-empty JSON string")
+	}
+
+	// Verify it's valid JSON by unmarshaling
+	var result map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		t.Errorf("Failed to unmarshal JSON: %v", err)
+	}
+
+	// Test MarshalJSON interface
+	jsonBytes, err := json.Marshal(eg)
+	if err != nil {
+		t.Fatalf("Failed to marshal using json.Marshal: %v", err)
+	}
+
+	if len(jsonBytes) == 0 {
+		t.Error("Expected non-empty JSON bytes")
+	}
+}
+
+func TestErrorGroupYAML(t *testing.T) {
+	eg := NewErrorGroup()
+	eg.Add(New("test error"))
+
+	// Test ToYAML
+	yamlStr, err := eg.ToYAML()
+	if err != nil {
+		t.Fatalf("Failed to convert to YAML: %v", err)
+	}
+
+	if yamlStr == "" {
+		t.Error("Expected non-empty YAML string")
+	}
+
+	// Verify it's valid YAML by unmarshaling
+	var result map[string]interface{}
+	if err := yaml.Unmarshal([]byte(yamlStr), &result); err != nil {
+		t.Errorf("Failed to unmarshal YAML: %v", err)
+	}
+
+	// Test MarshalYAML interface
+	yamlData, err := yaml.Marshal(eg)
+	if err != nil {
+		t.Fatalf("Failed to marshal using yaml.Marshal: %v", err)
+	}
+
+	if len(yamlData) == 0 {
+		t.Error("Expected non-empty YAML bytes")
+	}
+}
+
+func TestErrorGroupSerializationWithWrappedErrors(t *testing.T) {
+	eg := NewErrorGroup()
+
+	// Create a chain of wrapped errors
+	rootErr := New("root cause")
+	wrappedErr := Wrap(rootErr, "wrapped error")
+	eg.Add(wrappedErr)
+
+	serializable := eg.ToSerialization()
+
+	if len(serializable.Errors) != 1 {
+		t.Fatalf("Expected 1 error, got %d", len(serializable.Errors))
+	}
+
+	err := serializable.Errors[0]
+	if err.Message != "wrapped error: root cause" {
+		t.Errorf("Expected wrapped message, got '%s'", err.Message)
+	}
+
+	if err.Cause == nil {
+		t.Error("Expected cause to be serialized")
+	}
+
+	if err.Cause.Message != "root cause" {
+		t.Errorf("Expected cause message 'root cause', got '%s'", err.Cause.Message)
+	}
+}
+
+func TestErrorGroupSerializationWithStandardErrors(t *testing.T) {
+	eg := NewErrorGroup()
+
+	// Add standard Go error
+	eg.Add(errors.New("standard error"))
+
+	serializable := eg.ToSerialization()
+
+	if len(serializable.Errors) != 1 {
+		t.Fatalf("Expected 1 error, got %d", len(serializable.Errors))
+	}
+
+	err := serializable.Errors[0]
+	if err.Type != "standard" {
+		t.Errorf("Expected type 'standard', got '%s'", err.Type)
+	}
+
+	if len(err.StackTrace) != 0 {
+		t.Error("Expected no stack trace for standard error")
+	}
+
+	if err.Metadata != nil {
+		t.Error("Expected no metadata for standard error")
+	}
+}
+
+func TestEmptyErrorGroupSerialization(t *testing.T) {
+	eg := NewErrorGroup()
+
+	serializable := eg.ToSerialization()
+
+	if serializable.ErrorCount != 0 {
+		t.Errorf("Expected 0 errors, got %d", serializable.ErrorCount)
+	}
+
+	if len(serializable.Errors) != 0 {
+		t.Errorf("Expected 0 serialized errors, got %d", len(serializable.Errors))
+	}
+
+	// Test JSON serialization of empty group
+	jsonStr, err := eg.ToJSON()
+	if err != nil {
+		t.Fatalf("Failed to serialize empty group to JSON: %v", err)
+	}
+
+	if !strings.Contains(jsonStr, `"error_count": 0`) {
+		t.Error("Expected error_count: 0 in JSON")
+	}
+}
+
+func BenchmarkErrorGroupSerialization(b *testing.B) {
+	eg := NewErrorGroup()
+	for i := 0; i < 10; i++ {
+		eg.Add(New("error").WithMetadata("index", i))
+	}
+
+	b.Run("JSON", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, err := eg.ToJSON()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	b.Run("YAML", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_, err := eg.ToYAML()
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/threshold.go
+++ b/threshold.go
@@ -13,6 +13,7 @@ type CircuitBreaker struct {
 	failureCount  int
 	lastFailure   time.Time
 	state         CircuitState
+	observer      Observer
 	mu            sync.RWMutex
 	onStateChange func(name string, from, to CircuitState)
 }
@@ -31,11 +32,21 @@ const (
 
 // NewCircuitBreaker creates a new circuit breaker.
 func NewCircuitBreaker(name string, maxFailures int, timeout time.Duration) *CircuitBreaker {
+	return NewCircuitBreakerWithObserver(name, maxFailures, timeout, nil)
+}
+
+// NewCircuitBreakerWithObserver creates a new circuit breaker with an observer.
+func NewCircuitBreakerWithObserver(name string, maxFailures int, timeout time.Duration, observer Observer) *CircuitBreaker {
+	if observer == nil {
+		observer = newNoopObserver()
+	}
+
 	return &CircuitBreaker{
 		name:        name,
 		maxFailures: maxFailures,
 		timeout:     timeout,
 		state:       CircuitClosed,
+		observer:    observer,
 	}
 }
 
@@ -44,6 +55,18 @@ func (cb *CircuitBreaker) OnStateChange(callback func(name string, from, to Circ
 	cb.mu.Lock()
 	cb.onStateChange = callback
 	cb.mu.Unlock()
+}
+
+// SetObserver sets an observer for the circuit breaker.
+func (cb *CircuitBreaker) SetObserver(observer Observer) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	if observer == nil {
+		observer = newNoopObserver()
+	}
+
+	cb.observer = observer
 }
 
 // RecordFailure records a failure and potentially opens the circuit.
@@ -106,7 +129,9 @@ func (cb *CircuitBreaker) transitionTo(newState CircuitState) {
 	oldState := cb.state
 	cb.state = newState
 
-	observer.RecordCircuitStateTransition(cb.name, oldState, newState)
+	if cb.observer != nil {
+		cb.observer.RecordCircuitStateTransition(cb.name, oldState, newState)
+	}
 
 	if cb.onStateChange != nil {
 		go cb.onStateChange(cb.name, oldState, newState)


### PR DESCRIPTION
- Add comprehensive JSON/YAML serialization for ErrorGroup with ToJSON(), ToYAML(), and MarshalJSON/MarshalYAML interfaces
- Implement StackFrame struct and StackIterator for programmatic stack trace inspection
- Add SerializableError type supporting metadata, stack traces, and error causality chains
- Support both ewrap custom errors and standard Go errors in serialization
- Include timestamped error collections with structured error representation
- Add comprehensive test suite covering serialization, iteration, and edge cases
- Switch to goccy/go-json for improved JSON performance
- Add serialization example demonstrating new capabilities

Breaking: ErrorGroup now includes additional dependencies (goccy/go-json, gopkg.in/yaml.v3)